### PR TITLE
fixed the email subscription check

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -153,11 +153,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
     public function isSubscribed($email, $list, $storeId)
     {
         $subscribed = $this->_subscribed;
-        $isSubscribed = $subscribed[$storeId][$list][$email];
-        if(!isset($isSubscribed)) {
+        if(!isset($subscribed[$storeId][$list][$email])) {
             return $this->_checkSubscription($email, $list, $storeId);
         }else{
-            return $isSubscribed;
+            return $subscribed[$storeId][$list][$email];
         }
     }
 
@@ -167,17 +166,17 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      * @param $storeId
      * @return bool
      */
-//    private function _checkSubscription($email, $list, $storeId){
-//        $collection = $this->_unsubscribe->getCollection();
-//        $collection->addFieldToFilter('main_table.email', array('eq' => $email))
-//            ->addFieldToFilter('main_table.list', array('eq' => $list))
-//            ->addFieldToFilter('main_table.store_id', array('eq' => $storeId));
-//        if ($collection->getSize() == 0) {
-//            $this->_subscribed[$storeId][$list][$email] = 'true';
-//            return true;
-//        } else {
-//            $this->_subscribed[$storeId][$list][$email] = 'false';
-//            return false;
-//        }
-//    }
+    private function _checkSubscription($email, $list, $storeId){
+        $collection = $this->_unsubscribe->getCollection();
+        $collection->addFieldToFilter('main_table.email', array('eq' => $email))
+            ->addFieldToFilter('main_table.list', array('eq' => $list))
+            ->addFieldToFilter('main_table.store_id', array('eq' => $storeId));
+        if ($collection->getSize() == 0) {
+            $this->_subscribed[$storeId][$list][$email] = 'true';
+            return true;
+        } else {
+            $this->_subscribed[$storeId][$list][$email] = 'false';
+            return false;
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     },
     "description": "Connect Mandrill with Magento",
     "type": "magento2-module",
-    "version": "3.0.9",
+    "version": "3.0.10",
     "authors": [
         {
             "name": "Ebizmarts Corp",


### PR DESCRIPTION
Function _checkSubscription was commented and isSubscribed function cause a notice because empty array value was addressed.

It would be advised to add unit tests for these methods. If they had existed, this bug would not have been necessary. I wanted to add the tests, but had some troubles running them. My employer would not be happy if I spent hours getting this to run, so I dropped this.