### PR TITLE
Fixed Reply-To header

### DIFF
--- a/Model/Message.php
+++ b/Model/Message.php
@@ -196,7 +196,7 @@ class Message implements \Magento\Framework\Mail\MessageInterface
     {
         $email = $this->_filterEmail($email);
         $name  = $this->_filterName($name);
-        $this->_headers[] = array('Reply-To'=>sprintf('%s <%s>',$name,$email));
+        $this->_headers['Reply-To'] = sprintf('%s <%s>', $name, $email);
         return $this;
     }
 


### PR DESCRIPTION
Reply-To header currently being added as an array rather than a key-value pair, resulting in missing Reply-To in resulting email.