### PR TITLE
New label name

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -12,13 +12,13 @@
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Config:etc/system_file.xsd">
     <system>
-        <tab id="magemonkey" translate="label" sortOrder="450">
-            <label>MageMonkey</label>
+        <tab id="mailchimp" translate="label" sortOrder="450">
+            <label>MailChimp</label>
         </tab>
         <section id="mandrill" translate="label" type="text" sortOrder="300" showInDefault="1" showInWebsite="1" showInStore="1">
             <class>separator-top</class>
-            <label>Mandrill</label>
-            <tab>magemonkey</tab>
+            <label>MailChimp</label>
+            <tab>mailchimp</tab>
             <resource>Ebizmarts_Mandrill::config_mandrill</resource>
             <group id="hint" translate="label" type="text" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="1">
                 <frontend_model>Ebizmarts\Mandrill\Block\Adminhtml\System\Config\Fieldset\Hint</frontend_model>

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -17,7 +17,7 @@
         </tab>
         <section id="mandrill" translate="label" type="text" sortOrder="300" showInDefault="1" showInWebsite="1" showInStore="1">
             <class>separator-top</class>
-            <label>MailChimp</label>
+            <label>Mandrill</label>
             <tab>mailchimp</tab>
             <resource>Ebizmarts_Mandrill::config_mandrill</resource>
             <group id="hint" translate="label" type="text" sortOrder="0" showInDefault="1" showInWebsite="1" showInStore="1">


### PR DESCRIPTION
The module was appearing below the Label "MageMonkey" instead of Mailchimp.
Before:
![screen shot 2017-08-30 at 9 29 02 am](https://user-images.githubusercontent.com/23635187/29874269-9e1e9b06-8d6c-11e7-832f-fac8b3d56c4a.png)

After:
![screen shot 2017-08-30 at 10 18 59 am](https://user-images.githubusercontent.com/23635187/29874294-acdabe7c-8d6c-11e7-8bd3-4f2899c2f89d.png)
