### PR TITLE
Magento 2.2 Compatibility Patch

### DIFF
--- a/Model/Transport.php
+++ b/Model/Transport.php
@@ -82,6 +82,10 @@ class Transport implements \Magento\Framework\Mail\TransportInterface
         return true;
     }
 
+    public function getMessage() {
+        return $this->message;
+    }
+
     private function processApiCallResult($result)
     {
         $currentResult = current($result);


### PR DESCRIPTION
There was one breaking change in Magento 2.2 - the Mail Transport interface added a new getMessage function requirement.

This change should be backward compatible.