### PR TITLE
Define API key as sensitive/system-specific configuration

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -18,4 +18,11 @@
     <type name="Magento\Config\Model\Config">
         <plugin name="mandrill-save" type="Ebizmarts\Mandrill\Model\Plugin\Config" sortOrder="10"/>
     </type>
+    <type name="Magento\Config\Model\Config\TypePool">
+        <arguments>
+            <argument name="sensitive" xsi:type="array">
+                <item name="mandrill/general/apikey" xsi:type="string">1</item>
+            </argument>
+        </arguments>
+    </type>
 </config>


### PR DESCRIPTION
Magento 2.2 introduced the notion of [sensitive/system-specific configuration](http://devdocs.magento.com/guides/v2.2/extension-dev-guide/configuration/sensitive-and-environment-settings.html).

Considering that the Mandrill API Key is both sensitive and system-specific, I think it is safe to define it as sensitive following the Magento 2 configuration guidelines.

I haven't tested it on previous version of Magento 2 but I guess the DI configuration will simply be ignored on those versions.