### PR TITLE
Add module dependency to Magento_Config

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="Ebizmarts_Mandrill" setup_version="3.0.13">
+        <sequence>
+            <module name="Magento_Config"/>
+        </sequence>
     </module>
 </config>


### PR DESCRIPTION
The module as a dependency with `Magento_Config` ([example](https://github.com/ebizmarts/magento2-mandrill/blob/91ae0eda76cc9a5fdb1f0a1c570f6bcd30e0c98d/etc/di.xml#L18)). It should be specified in its configuration.

