### PR TITLE
Initial updates for Magento 2.3 and PHP 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 dist: trusty
 language: php
 php:
-  #- 5.6
-  - 7.0
   - 7.1
+  - 7.2
 
 env:
   - TEST_SUITE=unittests
@@ -18,7 +17,7 @@ script:
   - cd ..
   - wget https://gist.githubusercontent.com/centerax/5e42abec89d62a1308ba/raw/4b3242361c0690e234266afb3520c2940ac1055a/auth.json
   - /bin/cp auth.json /home/travis/.config/composer
-  - composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition=2.2.4
+  - composer create-project --repository-url=https://repo.magento.com/ magento/project-community-edition=2.3.0
   - mkdir -p project-community-edition/app/code/Ebizmarts/Mandrill
   - /bin/cp -r magento2-mandrill/* project-community-edition/app/code/Ebizmarts/Mandrill
   - sh -c "if [ '$TEST_SUITE' = 'unittests' ]; then cd project-community-edition && /bin/cp app/code/Ebizmarts/Mandrill/phpunit_config.xml dev/tests/unit/ && ./vendor/bin/phpunit -c dev/tests/unit/phpunit_config.xml app/code/Ebizmarts/Mandrill/Test/Unit --coverage-text; fi"

--- a/Controller/Adminhtml/Email/Test.php
+++ b/Controller/Adminhtml/Email/Test.php
@@ -10,7 +10,6 @@
  */
 namespace Ebizmarts\Mandrill\Controller\Adminhtml\Email;
 
-use Magento\Framework\Object;
 use Magento\Framework\Controller\ResultFactory;
 
 class Test extends \Magento\Backend\App\Action
@@ -35,7 +34,7 @@ class Test extends \Magento\Backend\App\Action
         \Magento\Framework\Mail\Template\TransportBuilder $transportBuilder,
         \Ebizmarts\Mandrill\Helper\Data $helper
     ) {
-    
+
         parent::__construct($context);
         $this->_transportBuilder = $transportBuilder;
         $this->_helper = $helper;

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,6 @@
     },
     "require" : {
         "mandrill/mandrill": "1.0.*",
-        "magento/module-sales": "^101.0.3"
+        "magento/module-sales": "^102.0.0"
     }
 }


### PR DESCRIPTION
As far as I can tell this is the only necessary change for PHP 7.2 and it should be backwards compatible. If you'd like me to just make a more sparse PR or update it to include checks for 2.2 and 2.3 I can change the code.

I will admit I haven't fully tested this yet but the code does compile.