### PR TITLE
Fixed issue where email's would not be sent becuase of missing From Address

### DIFF
--- a/Model/Message.php
+++ b/Model/Message.php
@@ -88,6 +88,16 @@ class Message extends \Magento\Framework\Mail\Message implements \Magento\Framew
         }
     }
 
+    public function setFromAddress($fromAddress, $fromName = null)
+    {
+        if ($this->mandrillHelper->isMandrillEnabled()) {
+            return $this->setFrom($fromAddress,$fromName);
+        }
+
+        return parent::setFromAddress($fromAddress,$fromName);
+
+    }
+
     public function setFrom($fromAddress, $name = null)
     {
         if ($this->mandrillHelper->isMandrillEnabled()) {


### PR DESCRIPTION
On a newly upgraded shop to magento 2.3.2 the email's was not getting sent because the setFromAddress method was missing :-)