### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,6 @@
     },
     "require" : {
         "mandrill/mandrill": "1.0.*",
-        "magento/framework": "102.0.*"
+        "magento/framework": "102.0.*||103.0.*"
     }
 }


### PR DESCRIPTION
### Situation - How did you get there?

Upgrading to Magento 2.4.2 from 2.3.6 using composer e.g.

php -d memory_limit=-1 /usr/local/bin/composer require magento/product-community-edition=2.4.2 --use-default-magento-values --no-update
php -d memory_limit=-1 /usr/local/bin/composer  update

### Problem - What went wrong?

...results in:

    - ebizmarts/magento2-mandrill 3.3.16 requires magento/framework 102.0.* -> satisfiable by magento/framework[102.0.6, 102.0.6-p1, 102.0.5-p2, 102.0.4-p2, 102.0.5, 102.0.3-p1, 102.0.4, 102.0.2-p2, 102.0.3, 102.0.2, 102.0.1, 102.0.0].

### Possible solution - How should it be?

Add 103.0.* to composer.json ?
 